### PR TITLE
Shaders: Add a missing semi-colon causing compilation error

### DIFF
--- a/src/renderers/shaders/ShaderChunk/morphcolor_vertex.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/morphcolor_vertex.glsl.js
@@ -14,7 +14,7 @@ export default /* glsl */`
 
 		#elif defined( USE_COLOR )
 
-			if ( morphTargetInfluences[ i ] != 0.0 ) vColor += getMorph( gl_VertexID, i, 2 ).rgb * morphTargetInfluences[ i ]
+			if ( morphTargetInfluences[ i ] != 0.0 ) vColor += getMorph( gl_VertexID, i, 2 ).rgb * morphTargetInfluences[ i ];
 
 		#endif
 


### PR DESCRIPTION
A very simple fix after I stumble upon a shader chunk with missing semi-colon at the end of line.

Thank you very much.